### PR TITLE
Fix "Uncaught ReferenceError: ext is not defined"

### DIFF
--- a/include.postload.js
+++ b/include.postload.js
@@ -472,7 +472,10 @@ function removeDotSegments(u) {
   }
 }
 
-if (document instanceof HTMLDocument)
+// In Chrome 37-39, the document_end content script (this one) runs properly, while the 
+// document_start content scripts (that defines ext) do not. Check whether variable ext
+// exists before continuing to avoid "Uncaught ReferenceError: ext is not defined".
+if ("ext" in window && document instanceof HTMLDocument)
 {
   // Use a contextmenu handler to save the last element the user right-clicked on.
   // To make things easier, we actually save the DOM event.


### PR DESCRIPTION
This patch is temporary and can be reverted once the Chromium bug
(https://crbug.com/416907) has been fixed.

To make merging/reverting the patch easier, I have changed the main if-block
to a function that takes the original if-body as a main function. The main
function is called whenever the bootstrapper has made sure that the environment
is ready. (The alternatives, disabling the content script or using XHR, were
not so appealing.)

Fixes
https://issues.adblockplus.org/ticket/1370
https://adblockplus.org/forum/viewtopic.php?f=10&t=25507

I hereby waive any rights of this contributed piece of software, you may do whatever you want with it (this comment is an alternative to signing the CLA at https://adblockplus.org/eyeo-contributor-license-agreement.pdf).
